### PR TITLE
marked decommissioned & archive this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # containerized-microservice-template
 
+**The projects that use this repository have been decommissioned. [See more here](https://mana.mozilla.org/wiki/display/SRE/Mozilla+API+Tombstone).**
+
 A github repo template using python3 with:
  - Using FastAPI framework (Pydantic, Swagger, included)
  - BDD testing strategies (using Gherkin and Behave)


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/DSRE-820

I believe that as part of decommissioning the former gcp.infra.mozilla.com mozilla-api-stage & mozilla-api-prod projects, this repository isn't used any longer and can be archived.

Making this PR to confirm that fact with the developers originally involved before I archive. Once you thumbs up, I'll go ahead and do so. If you want to keep this repository, lets figure out who should now own it and where it should go.

Thanks!